### PR TITLE
Make include_org default configurable

### DIFF
--- a/illumio/accessmanagement/user.py
+++ b/illumio/accessmanagement/user.py
@@ -10,10 +10,11 @@ License:
 """
 from dataclasses import dataclass
 
-from illumio.util import IllumioObject
+from illumio.util import IllumioObject, pce_api
 
 
 @dataclass
+@pce_api('users', is_global=True)
 class User(IllumioObject):
     username: str = None
     last_login_on: str = None

--- a/illumio/pce.py
+++ b/illumio/pce.py
@@ -60,6 +60,8 @@ class PolicyComputeEngine:
     Attributes:
         base_url: the base URL for API calls to the PCE. Has the form
             http[s]://<DOMAIN_NAME>:<PORT>/api/<API_VERSION>
+        include_org: flag denoting whether to prepend the orgs subpath
+            to request endpoints by default. Defaults to True.
         org_id: the PCE organization ID.
         container_clusters: Container Clusters API.
         container_workload_profiles: Container Cluster Workload Profiles API.
@@ -92,6 +94,7 @@ class PolicyComputeEngine:
         self._session.headers.update({'Accept': 'application/json'})
         protocol, url = parse_url(url)
         self.base_url = "{}://{}:{}/api/{}".format(protocol, url, port, version)
+        self.include_org = True
         self.org_id = org_id
         self._setup_retry()
 
@@ -128,14 +131,14 @@ class PolicyComputeEngine:
         """
         self._session.proxies.update({'http': http_proxy, 'https': https_proxy})
 
-    def _request(self, method: str, endpoint: str, include_org=True, **kwargs) -> Response:
+    def _request(self, method: str, endpoint: str, include_org: bool = None, **kwargs) -> Response:
         """Makes an API call to the PCE.
 
         Args:
             method (str): the HTTP request method. Supports the same verbs as `requests.request`.
             endpoint (str): the API endpoint to call.
             include_org (bool, optional): whether or not to include /orgs/{org_id} in the API call.
-                Defaults to True.
+                Defaults to the value of the `include_org` class attribute.
 
         Raises:
             IllumioApiException: if the response is unsuccessful (status code >399).
@@ -144,6 +147,7 @@ class PolicyComputeEngine:
             requests.Response: the `Response` object returned from a successful request.
         """
         try:
+            include_org = self.include_org if include_org is None else include_org
             response = None  # avoid reference before assignment errors in case of cxn failure
             url = self._build_url(endpoint, include_org)
             self._encode_body(kwargs)
@@ -265,7 +269,7 @@ class PolicyComputeEngine:
 
             collection_href = self._async_poll(location, retry_after)
 
-            response = self.get(collection_href, include_org=False)
+            response = self.get(collection_href)
             response.raise_for_status()
             return response
         except Exception as e:
@@ -316,7 +320,8 @@ class PolicyComputeEngine:
             bool: True if the call is successful, otherwise False.
         """
         try:
-            self.get('/health', include_org=False, **kwargs)
+            kwargs['include_org'] = False
+            self.get('/health', **kwargs)
             return True
         except IllumioApiException:
             return False
@@ -368,7 +373,8 @@ class PolicyComputeEngine:
             Returns:
                 IllumioObject: the object json, decoded to its IllumioObject equivalent.
             """
-            response = self.pce.get(href_from(reference), include_org=False, **kwargs)
+            kwargs['include_org'] = False
+            response = self.pce.get(href_from(reference), **kwargs)
             return self.object_cls.from_json(response.json())
 
         def get(self, policy_version: str = DRAFT, parent: Union[str, Reference, dict] = None, **kwargs) -> List[IllumioObject]:
@@ -406,8 +412,9 @@ class PolicyComputeEngine:
             Returns:
                 List[IllumioObject]: the returned list of decoded objects.
             """
+            kwargs['include_org'] = False
             endpoint = self._build_endpoint(policy_version, parent)
-            response = self.pce.get(endpoint, include_org=False, **kwargs)
+            response = self.pce.get(endpoint, **kwargs)
             return [self.object_cls.from_json(o) for o in response.json()]
 
         def get_all(self, policy_version: str = DRAFT, parent: Union[str, Reference, dict] = None, **kwargs) -> List[IllumioObject]:
@@ -428,6 +435,7 @@ class PolicyComputeEngine:
             Returns:
                 List[IllumioObject]: the returned list of decoded objects.
             """
+            kwargs['include_org'] = False
             params = kwargs.get('params', {})
             endpoint = self._build_endpoint(policy_version, parent)
 
@@ -439,7 +447,7 @@ class PolicyComputeEngine:
                 filtered_object_count = response.headers['X-Total-Count']
                 kwargs['params'] = {**params, **{'max_results': int(filtered_object_count)}}
 
-            response = self.pce.get(endpoint, include_org=False, **kwargs)
+            response = self.pce.get(endpoint, **kwargs)
             return [self.object_cls.from_json(o) for o in response.json()]
 
         def get_async(self, policy_version: str = DRAFT, parent: Union[str, Reference, dict] = None, **kwargs) -> List[IllumioObject]:
@@ -456,6 +464,7 @@ class PolicyComputeEngine:
             Returns:
                 List[IllumioObject]: the returned list of decoded objects.
             """
+            kwargs['include_org'] = False
             endpoint = self._build_endpoint(policy_version, parent)
             response = self.pce.get_collection(endpoint, **kwargs)
             return [self.object_cls.from_json(o) for o in response.json()]
@@ -488,8 +497,9 @@ class PolicyComputeEngine:
                 IllumioObject: the created object.
             """
             kwargs['json'] = body
+            kwargs['include_org'] = False
             endpoint = self._build_endpoint(DRAFT, parent)
-            response = self.pce.post(endpoint, include_org=False, **kwargs)
+            response = self.pce.post(endpoint, **kwargs)
             return self._parse_response_body(response.json())
 
         def _parse_response_body(self, json_response):
@@ -528,7 +538,8 @@ class PolicyComputeEngine:
                 body (Any): the update data.
             """
             kwargs['json'] = body
-            self.pce.put(href_from(reference), include_org=False, **kwargs)
+            kwargs['include_org'] = False
+            self.pce.put(href_from(reference), **kwargs)
 
         def delete(self, reference: Union[str, Reference, dict], **kwargs) -> None:
             """Deletes an object in the PCE.
@@ -538,15 +549,17 @@ class PolicyComputeEngine:
             Args:
                 reference (Union[str, Reference, dict]): the HREF of the object to delete.
             """
-            self.pce.delete(href_from(reference), include_org=False, **kwargs)
+            kwargs['include_org'] = False
+            self.pce.delete(href_from(reference), **kwargs)
 
         def _bulk_change(self, objects: List[IllumioObject], method: str, success_status: str, **kwargs) -> List[dict]:
             results = []
+            kwargs['include_org'] = False
             while objects:
                 kwargs['json'] = objects[:BULK_CHANGE_LIMIT]
                 objects = objects[BULK_CHANGE_LIMIT:]
                 endpoint = self._build_endpoint(DRAFT, None)
-                response = self.pce.put('{}/{}'.format(endpoint, method), include_org=False, **kwargs)
+                response = self.pce.put('{}/{}'.format(endpoint, method), **kwargs)
                 for result in response.json():
                     errors = result.get('errors', [])
                     if success_status and result['status'] != success_status:
@@ -658,6 +671,7 @@ class PolicyComputeEngine:
         params = kwargs.get('params', {})
         # retrieve by name as each org will use a different ID
         kwargs['params'] = {**params, **{'name': ANY_IP_LIST_NAME}}
+        kwargs['include_org'] = True
         response = self.get('/sec_policy/active/ip_lists', **kwargs)
         return IPList.from_json(response.json()[0])
 
@@ -671,7 +685,7 @@ class PolicyComputeEngine:
             str: the pairing key value.
         """
         kwargs['json'] = {}
-        response = self.post('{}/pairing_key'.format(pairing_profile_href), include_org=False, **kwargs)
+        response = self.post('{}/pairing_key'.format(pairing_profile_href), **kwargs)
         return response.json().get('activation_code')
 
     @deprecated(deprecated_in='1.0.0')
@@ -697,6 +711,7 @@ class PolicyComputeEngine:
                 provided query.
         """
         kwargs['json'] = traffic_query
+        kwargs['include_org'] = True
         response = self.post('/traffic_flows/traffic_analysis_queries', **kwargs)
         return [TrafficFlow.from_json(flow) for flow in response.json()]
 
@@ -803,6 +818,7 @@ class PolicyComputeEngine:
             kwargs['json'] = traffic_query
             headers = kwargs.get('headers', {})
             kwargs['headers'] = {**headers, **{'Content-Type': 'application/json', 'Prefer': 'respond-async'}}
+            kwargs['include_org'] = True
             response = self.post('/traffic_flows/async_queries', **kwargs)
             response.raise_for_status()
             query_status = response.json()
@@ -810,7 +826,7 @@ class PolicyComputeEngine:
 
             collection_href = self._async_poll(location)
 
-            response = self.get(collection_href, include_org=False)
+            response = self.get(collection_href)
             response.raise_for_status()
             return [TrafficFlow.from_json(flow) for flow in response.json()]
         except Exception as e:
@@ -853,6 +869,7 @@ class PolicyComputeEngine:
         """
         policy_changeset = PolicyChangeset.build(hrefs)
         kwargs['json'] = {'update_description': change_description, 'change_subset': policy_changeset}
+        kwargs['include_org'] = True
         response = self.post('/sec_policy', **kwargs)
         return PolicyVersion.from_json(response.json())
 

--- a/illumio/pce.py
+++ b/illumio/pce.py
@@ -75,6 +75,7 @@ class PolicyComputeEngine:
         security_principals: Security Principals API.
         service_bindings: Service Bindings API.
         services: Services API.
+        users: Users API.
         vens: VENs API.
         virtual_services: Virtual Services API.
         workloads: Workloads API.

--- a/illumio/pce.pyi
+++ b/illumio/pce.pyi
@@ -132,6 +132,7 @@ class PolicyComputeEngine:
     security_principals: _PCEObjectAPI
     service_bindings: _PCEObjectAPI
     services: _PCEObjectAPI
+    users: _PCEObjectAPI
     vens: _PCEObjectAPI
     virtual_services: _PCEObjectAPI
     workloads: _PCEObjectAPI

--- a/tests/unit/mocks.py
+++ b/tests/unit/mocks.py
@@ -44,6 +44,7 @@ OBJECT_TYPE_REF_MAP = {
     'security_principals': _gen_sid,
     'service_bindings': _gen_int_id,
     'services': _gen_int_id,
+    'users': _gen_int_id,
     'vens': _gen_uuid,
     'virtual_services': _gen_uuid,
     'workloads': _gen_uuid
@@ -54,8 +55,8 @@ class PCEObjectMock(object):
     """
     Base class for PCE object mocks
     """
-    base_pattern = '^/api/v2/orgs/\d+(?:/sec_policy/(?:draft|active))?/([a-zA-Z_\-]+)'
-    href_pattern = '^/api/v2(/orgs/\d+(?:/sec_policy/(?:draft|active))?(?:/[a-zA-Z_\-]+/[a-zA-Z0-9\-]+)+)$'
+    base_pattern = '^/api/v2(?:/orgs/\d+)?(?:/sec_policy/(?:draft|active))?/([a-zA-Z_\-]+)'
+    href_pattern = '^/api/v2((?:/orgs/\d+)?(?:/sec_policy/(?:draft|active))?(?:/[a-zA-Z_\-]+/[a-zA-Z0-9\-]+)+)$'
 
     def __init__(self) -> None:
         self.mock_objects = []
@@ -134,7 +135,7 @@ class PCEObjectMock(object):
         if not match:
             raise Exception("Invalid path: {}".format(path))
         object_type = match.group(1)
-        href = '/orgs/{}/{}'.format(path.split('/orgs/')[-1], OBJECT_TYPE_REF_MAP[object_type]())
+        href = '/{}/{}'.format(path.split('/api/v2/')[-1], OBJECT_TYPE_REF_MAP[object_type]())
         body['href'] = href
         self.mock_objects.append(body)
         return body
@@ -163,3 +164,11 @@ class PCEObjectMock(object):
                     return
             raise Exception("Attempting to delete invalid or missing object")
         raise Exception("Invalid HREF passed to delete_mock_object")
+
+
+class MockResponse():
+    content = ''
+    headers = {'X-Total-Count': 0}
+
+    def raise_for_status(self): pass
+    def json(self): return {}


### PR DESCRIPTION
Make include_org default configurable at the PolicyComputeEngine class level

* make include_org configurable at the PCE class level
* explicitly set include_org argument for all PCE API wrapper functions
* stub out users api
* add unit tests to validate different request paths and include_org values

- [x] I've read and followed the [contribution guidelines](CONTRIBUTING.md) for this PR  
