### PR TITLE
Fix PairingProfile Key Field Encoding

### DIFF
--- a/illumio/util/jsonutils.py
+++ b/illumio/util/jsonutils.py
@@ -260,5 +260,6 @@ __all__ = [
     'IllumioObject',
     'MutableObject',
     'ImmutableObject',
-    'href_from'
+    'href_from',
+    'flatten_ref'
 ]

--- a/illumio/workloads/pairingprofile.py
+++ b/illumio/workloads/pairingprofile.py
@@ -8,7 +8,7 @@ Copyright:
 License:
     Apache2, see LICENSE for more details.
 """
-from dataclasses import dataclass
+from dataclasses import dataclass, fields
 from typing import List, Union
 
 from illumio import IllumioException
@@ -17,7 +17,9 @@ from illumio.util import (
     MutableObject,
     EnforcementMode,
     VisibilityLevel,
-    pce_api
+    pce_api,
+    ignore_empty_keys,
+    flatten_ref
 )
 
 
@@ -73,3 +75,24 @@ class PairingProfile(MutableObject):
         if self.visibility_level and not self.visibility_level in VisibilityLevel:
             raise IllumioException("Invalid visibility_level: {}".format(self.visibility_level))
         super()._validate()
+
+    def _encode(self):
+        """Defines custom encoding rules for pairing profiles.
+
+        The allowed_uses_per_key and key_lifespan parameters have strict schema
+        contraints in the PCE - values must either be 'unlimited' or an integer
+        which we enforce here. Other fields use the default encoding method and
+        labels is flattened to just include HREFs.
+        """
+        result = []
+        for f in fields(self):
+            value = getattr(self, f.name)
+            if f.name in ['allowed_uses_per_key', 'key_lifespan']:
+                if isinstance(value, str) and value != 'unlimited':
+                    if not value.isnumeric():
+                        raise IllumioException("Invalid '{}' value: must be 'unlimited' or int".format(f.name))
+                    value = int(value)
+            if f.name == 'labels':
+                value = flatten_ref(f.type, value)
+            result.append((f.name, value))
+        return ignore_empty_keys(result)

--- a/tests/unit/test_unit_pairing_profiles.py
+++ b/tests/unit/test_unit_pairing_profiles.py
@@ -40,6 +40,36 @@ def mock_requests(requests_mock, get_callback, post_callback, put_callback, dele
     requests_mock.register_uri('POST', key_pattern, json=mock_pairing_key)
 
 
+@pytest.mark.parametrize(
+    "key_lifespan,expected", [
+        ('unlimited', 'unlimited'),
+        (60, 60),
+        ('60', 60)
+    ]
+)
+def test_encoded_key_lifespan_value(key_lifespan, expected):
+    profile = PairingProfile(
+        name='PP-TEST',
+        key_lifespan=key_lifespan
+    )
+    assert profile._encode()['key_lifespan'] == expected
+
+
+@pytest.mark.parametrize(
+    "allowed_uses_per_key,expected", [
+        ('unlimited', 'unlimited'),
+        (60, 60),
+        ('60', 60)
+    ]
+)
+def test_encoded_allowed_uses_per_key_value(allowed_uses_per_key, expected):
+    profile = PairingProfile(
+        name='PP-TEST',
+        allowed_uses_per_key=allowed_uses_per_key
+    )
+    assert profile._encode()['allowed_uses_per_key'] == expected
+
+
 def test_get_profiles_by_name(pce):
     pairing_profiles = pce.pairing_profiles.get(params={'name': 'PP-'})
     assert len(pairing_profiles) == 2


### PR DESCRIPTION
Changes PairingProfile to use a custom encoder so that encoded key fields adhere to PCE API schema.

* export flatten_ref function from `jsonutils` for use in `PairingProfile::_encode`
* add unit tests to check encoded `key_lifespan` and `allowed_uses_per_key` values

- [x] I've read and followed the [contribution guidelines](CONTRIBUTING.md) for this PR  
