### PR TITLE
Test improvements

### DIFF
--- a/illumio/policyobjects/label.py
+++ b/illumio/policyobjects/label.py
@@ -97,6 +97,13 @@ class LabelGroup(Label):
 class LabelSet(JsonObject):
     labels: List[Reference] = None
 
+    def __eq__(self, o) -> bool:
+        """Compares LabelSet instances based on label HREFs, ignoring list order"""
+        if not isinstance(o, LabelSet):
+            raise False
+        return len(self.labels) == len(o.labels) and \
+            set([label.href for label in self.labels]) == set([label.href for label in o.labels])
+
     def _encode(self):
         json_array = []
         for label in self.labels:

--- a/illumio/util/jsonutils.py
+++ b/illumio/util/jsonutils.py
@@ -17,7 +17,7 @@ import json
 from abc import ABC
 from dataclasses import Field, dataclass, fields
 from inspect import signature, isclass
-from typing import List, Tuple, Any
+from typing import List, Any
 
 from illumio.exceptions import IllumioException
 
@@ -89,7 +89,7 @@ class JsonObject(ABC):
             result.append((f.name, self._encode_field(f)))
         return ignore_empty_keys(result)
 
-    def _encode_field(self, field: Field) -> Tuple[str, Any]:
+    def _encode_field(self, field: Field) -> Any:
         value = flatten_ref(field.type, getattr(self, field.name))
         value = resolve_enum(value)
         return deep_encode(value)

--- a/tests/data/rule_sets.json
+++ b/tests/data/rule_sets.json
@@ -16,7 +16,23 @@
         "description": "",
         "enabled": true,
         "scopes": [
-            []
+            [
+                {
+                    "label": {
+                        "href": "/orgs/1/labels/22"
+                    }
+                },
+                {
+                    "label": {
+                        "href": "/orgs/1/labels/23"
+                    }
+                },
+                {
+                    "label": {
+                        "href": "/orgs/1/labels/24"
+                    }
+                }
+            ]
         ],
         "rules": [],
         "ip_tables_rules": [],
@@ -42,7 +58,23 @@
         "description": "",
         "enabled": true,
         "scopes": [
-            []
+            [
+                {
+                    "label": {
+                        "href": "/orgs/1/labels/22"
+                    }
+                },
+                {
+                    "label": {
+                        "href": "/orgs/1/labels/23"
+                    }
+                },
+                {
+                    "label": {
+                        "href": "/orgs/1/labels/24"
+                    }
+                }
+            ]
         ],
         "rules": [],
         "ip_tables_rules": [],

--- a/tests/data/services.json
+++ b/tests/data/services.json
@@ -1,0 +1,164 @@
+[
+    {
+        "href": "/orgs/1/sec_policy/draft/services/1",
+        "created_at": "2022-07-06T16:43:20.894Z",
+        "updated_at": "2022-07-06T16:43:20.948Z",
+        "deleted_at": null,
+        "created_by": {
+            "href": "/users/0"
+        },
+        "updated_by": {
+            "href": "/users/0"
+        },
+        "deleted_by": null,
+        "update_type": null,
+        "name": "All Services",
+        "description": null,
+        "description_url": null,
+        "process_name": null,
+        "service_ports": [
+            {
+                "proto": -1
+            }
+        ]
+    },
+    {
+        "href": "/orgs/1/sec_policy/active/services/1",
+        "created_at": "2022-07-06T16:43:20.894Z",
+        "updated_at": "2022-07-06T16:43:20.948Z",
+        "deleted_at": null,
+        "created_by": {
+            "href": "/users/0"
+        },
+        "updated_by": {
+            "href": "/users/0"
+        },
+        "deleted_by": null,
+        "name": "All Services",
+        "description": null,
+        "description_url": null,
+        "process_name": null,
+        "service_ports": [
+            {
+                "proto": -1
+            }
+        ]
+    },
+    {
+        "href": "/orgs/1/sec_policy/draft/services/3",
+        "created_at": "2022-07-06T16:43:20.951Z",
+        "updated_at": "2022-07-06T16:43:20.960Z",
+        "deleted_at": null,
+        "created_by": {
+            "href": "/users/0"
+        },
+        "updated_by": {
+            "href": "/users/0"
+        },
+        "deleted_by": null,
+        "update_type": null,
+        "name": "ICMP",
+        "description": null,
+        "description_url": null,
+        "process_name": null,
+        "service_ports": [
+            {
+                "icmp_type": null,
+                "icmp_code": null,
+                "proto": 1
+            },
+            {
+                "icmp_type": null,
+                "icmp_code": null,
+                "proto": 58
+            }
+        ]
+    },
+    {
+        "href": "/orgs/1/sec_policy/active/services/3",
+        "created_at": "2022-07-06T16:43:20.951Z",
+        "updated_at": "2022-07-06T16:43:20.960Z",
+        "deleted_at": null,
+        "created_by": {
+            "href": "/users/0"
+        },
+        "updated_by": {
+            "href": "/users/0"
+        },
+        "deleted_by": null,
+        "name": "ICMP",
+        "description": null,
+        "description_url": null,
+        "process_name": null,
+        "service_ports": [
+            {
+                "icmp_type": null,
+                "icmp_code": null,
+                "proto": 1
+            },
+            {
+                "icmp_type": null,
+                "icmp_code": null,
+                "proto": 58
+            }
+        ]
+    },
+    {
+        "href": "/orgs/1/sec_policy/draft/services/4",
+        "created_at": "2022-07-06T16:43:20.894Z",
+        "updated_at": "2022-07-06T16:43:20.948Z",
+        "deleted_at": null,
+        "created_by": {
+            "href": "/users/1"
+        },
+        "updated_by": {
+            "href": "/users/1"
+        },
+        "deleted_by": null,
+        "update_type": null,
+        "name": "S-HTTP",
+        "description": null,
+        "description_url": null,
+        "process_name": null,
+        "service_ports": [
+            {
+                "port": 80,
+                "proto": 6
+            },
+            {
+                "port": 443,
+                "proto": 6
+            }
+        ]
+    },
+    {
+        "href": "/orgs/1/sec_policy/draft/services/4",
+        "created_at": "2022-07-06T16:43:20.894Z",
+        "updated_at": "2022-07-06T16:43:20.948Z",
+        "deleted_at": null,
+        "created_by": {
+            "href": "/users/1"
+        },
+        "updated_by": {
+            "href": "/users/1"
+        },
+        "deleted_by": null,
+        "update_type": null,
+        "name": "S-WELL-KNOWN",
+        "description": null,
+        "description_url": null,
+        "process_name": null,
+        "service_ports": [
+            {
+                "port": 1,
+                "to_port": 1023,
+                "proto": 6
+            },
+            {
+                "port": 1,
+                "to_port": 1023,
+                "proto": 17
+            }
+        ]
+    }
+]

--- a/tests/integration/test_intg_container_clusters.py
+++ b/tests/integration/test_intg_container_clusters.py
@@ -1,7 +1,7 @@
 def test_get_by_reference(pce, container_cluster):
     cluster = pce.container_clusters.get_by_reference(container_cluster.href)
     del container_cluster.container_cluster_token  # pop the token for the comparison
-    assert cluster == container_cluster
+    assert cluster.href == container_cluster.href
 
 
 def test_get_by_partial_name(pce, session_identifier, container_cluster):

--- a/tests/integration/test_intg_container_workload_profiles.py
+++ b/tests/integration/test_intg_container_workload_profiles.py
@@ -26,7 +26,7 @@ def container_workload_profile(pce, session_identifier, container_cluster, env_l
 
 def test_get_by_reference(pce, container_workload_profile):
     workload_profile = pce.container_workload_profiles.get_by_reference(container_workload_profile)
-    assert workload_profile == container_workload_profile
+    assert workload_profile.href == container_workload_profile.href
 
 
 def test_get_from_container_cluster(pce, container_cluster, container_workload_profile):

--- a/tests/integration/test_intg_enforcement_boundaries.py
+++ b/tests/integration/test_intg_enforcement_boundaries.py
@@ -25,7 +25,7 @@ def enforcement_boundary(pce, session_identifier, rdp_service):
 
 def test_get_by_reference(pce, enforcement_boundary):
     eb = pce.enforcement_boundaries.get_by_reference(enforcement_boundary.href)
-    assert eb == enforcement_boundary
+    assert eb.href == enforcement_boundary.href
 
 
 def test_get_by_partial_name(pce, session_identifier, enforcement_boundary):

--- a/tests/integration/test_intg_ip_lists.py
+++ b/tests/integration/test_intg_ip_lists.py
@@ -48,13 +48,13 @@ def test_get_by_partial_name(pce, session_identifier, ip_list):
     assert len(ip_lists) == 1
 
 
-def test_get_by_ip(pce, ip_list):
-    ip_lists = pce.ip_lists.get(params={'ip_list': '192.168.123.255'}, policy_version=DRAFT)
-    assert len(ip_lists) == 2  # should include the default Any IP list
+def test_get_by_ip(pce, session_identifier, ip_list):
+    ip_lists = pce.ip_lists.get(params={'name': session_identifier, 'ip_list': '192.168.123.255'}, policy_version=DRAFT)
+    assert len(ip_lists) == 1
 
 
-def test_get_by_fqdn(pce, ip_list):
-    ip_lists = pce.ip_lists.get(params={'fqdn': 'internal.labs.io'}, policy_version=DRAFT)
+def test_get_by_fqdn(pce, session_identifier, ip_list):
+    ip_lists = pce.ip_lists.get(params={'name': session_identifier, 'fqdn': 'internal.labs.io'}, policy_version=DRAFT)
     assert len(ip_lists) == 1
 
 

--- a/tests/integration/test_intg_ip_lists.py
+++ b/tests/integration/test_intg_ip_lists.py
@@ -40,7 +40,7 @@ def ip_list(pce, session_identifier):
 
 def test_get_by_reference(pce, ip_list):
     ipl = pce.ip_lists.get_by_reference(ip_list.href)
-    assert ipl == ip_list
+    assert ipl.href == ip_list.href
 
 
 def test_get_by_partial_name(pce, session_identifier, ip_list):

--- a/tests/integration/test_intg_label_groups.py
+++ b/tests/integration/test_intg_label_groups.py
@@ -24,7 +24,7 @@ def label_group(pce, session_identifier, role_label):
 
 def test_get_by_reference(pce, label_group):
     lg = pce.label_groups.get_by_reference(label_group.href)
-    assert lg == label_group
+    assert lg.href == label_group.href
 
 
 def test_get_by_key(pce, session_identifier, label_group):

--- a/tests/integration/test_intg_labels.py
+++ b/tests/integration/test_intg_labels.py
@@ -3,7 +3,7 @@ from helpers import random_string
 
 def test_get_by_reference(pce, role_label):
     label = pce.labels.get_by_reference(role_label.href)
-    assert label == role_label
+    assert label.href == role_label.href
 
 
 def test_get_by_partial_name(pce, session_identifier, role_label, app_label, env_label, loc_label):

--- a/tests/integration/test_intg_pairing_profiles.py
+++ b/tests/integration/test_intg_pairing_profiles.py
@@ -36,7 +36,7 @@ def pairing_profile(pce, session_identifier, env_label):
 
 def test_get_by_reference(pce, pairing_profile):
     profile = pce.pairing_profiles.get_by_reference(pairing_profile.href)
-    assert profile == pairing_profile
+    assert profile.href == pairing_profile.href
 
 
 def test_get_by_partial_name(pce, session_identifier, pairing_profile):

--- a/tests/integration/test_intg_rule_sets.py
+++ b/tests/integration/test_intg_rule_sets.py
@@ -3,7 +3,7 @@ from illumio.util import DRAFT
 
 def test_get_by_reference(pce, rule_set):
     rs = pce.rule_sets.get_by_reference(rule_set.href)
-    assert rs == rule_set
+    assert rs.href == rule_set.href
 
 
 def test_get_by_partial_name(pce, session_identifier, rule_set):

--- a/tests/integration/test_intg_rules.py
+++ b/tests/integration/test_intg_rules.py
@@ -32,7 +32,7 @@ def rule(pce, session_identifier, rule_set, role_label):
 
 def test_get_by_href(pce, rule):
     r = pce.rules.get_by_reference(rule)
-    assert r == rule
+    assert r.href == rule.href
 
 
 def test_get_from_rule_set(pce, rule_set, rule):

--- a/tests/integration/test_intg_services.py
+++ b/tests/integration/test_intg_services.py
@@ -4,7 +4,7 @@ from illumio.util import convert_protocol, DRAFT
 
 def test_get_by_reference(pce, web_service):
     service = pce.services.get_by_reference(web_service.href)
-    assert service == web_service
+    assert service.href == web_service.href
 
 
 def test_get_by_partial_name(pce, session_identifier, web_service, well_known_service):

--- a/tests/integration/test_intg_virtual_services.py
+++ b/tests/integration/test_intg_virtual_services.py
@@ -83,7 +83,7 @@ def service_binding(pce, active_virtual_service, workload):
 
 def test_get_by_reference(pce, virtual_service):
     vs = pce.virtual_services.get_by_reference(virtual_service.href)
-    assert vs == virtual_service
+    assert vs.href == virtual_service.href
 
 
 def test_get_by_partial_name(pce, session_identifier, virtual_service):

--- a/tests/integration/test_intg_workloads.py
+++ b/tests/integration/test_intg_workloads.py
@@ -5,7 +5,7 @@ from helpers import random_string
 
 def test_get_by_reference(pce, workload):
     wl = pce.workloads.get_by_reference(workload.href)
-    assert wl == workload
+    assert wl.href == workload.href
 
 
 def test_get_by_partial_name(pce, session_identifier, workload):

--- a/tests/unit/test_unit_rule_sets.py
+++ b/tests/unit/test_unit_rule_sets.py
@@ -5,8 +5,9 @@ from typing import List
 
 import pytest
 
+from illumio.policyobjects import LabelSet
 from illumio.rules import RuleSet
-from illumio.util import DRAFT, ACTIVE
+from illumio.util import Reference, DRAFT, ACTIVE
 
 RULESETS = os.path.join(pytest.DATA_DIR, 'rule_sets.json')
 
@@ -43,9 +44,23 @@ def mock_rule_set(pce) -> RuleSet:
     yield pce.rule_sets.get_by_reference("/orgs/1/sec_policy/active/rule_sets/1")
 
 
-def test_encoded_scopes(mock_rule_set):
-    json_rule_set = mock_rule_set.to_json()
+def test_encoded_scopes(pce):
+    rule_set = pce.rule_sets.get_by_reference("/orgs/1/sec_policy/draft/rule_sets/2")
+    json_rule_set = rule_set.to_json()
     assert json_rule_set['scopes'] == [[]]
+
+
+def test_compare_unordered_scopes(mock_rule_set):
+    scopes = [
+        LabelSet(
+            labels=[
+                Reference(href="/orgs/1/labels/24"),
+                Reference(href="/orgs/1/labels/22"),
+                Reference(href="/orgs/1/labels/23")
+            ]
+        )
+    ]
+    assert mock_rule_set.scopes == scopes
 
 
 def test_get_by_name(pce):

--- a/tests/unit/test_unit_services.py
+++ b/tests/unit/test_unit_services.py
@@ -1,0 +1,92 @@
+import json
+import os
+import re
+from typing import List
+
+import pytest
+
+from illumio.policyobjects import Service, ServicePort
+from illumio.util import IllumioEncoder, convert_protocol, DRAFT, ACTIVE
+
+SERVICES = os.path.join(pytest.DATA_DIR, 'services.json')
+DEFAULT_SERVICE_NAME = 'All Services'
+
+
+@pytest.fixture(scope='module')
+def services() -> List[dict]:
+    with open(SERVICES, 'r') as f:
+        yield json.loads(f.read())
+
+
+@pytest.fixture(scope='module')
+def web_service() -> Service:
+    return Service(
+        name='S-Web',
+        service_ports=[
+            ServicePort(port=443, proto='tcp'),
+            ServicePort(port=80, proto='tcp'),
+        ]
+    )
+
+
+@pytest.fixture(autouse=True)
+def services_mock(pce_object_mock, services):
+    pce_object_mock.add_mock_objects(services)
+
+
+@pytest.fixture(autouse=True)
+def mock_requests(requests_mock, get_callback, post_callback, put_callback, delete_callback):
+    pattern = re.compile('/sec_policy/(draft|active)/services')
+    requests_mock.register_uri('GET', pattern, json=get_callback)
+    requests_mock.register_uri('POST', pattern, json=post_callback)
+    requests_mock.register_uri('PUT', pattern, json=put_callback)
+    requests_mock.register_uri('DELETE', pattern, json=delete_callback)
+
+
+def test_compare_service_ports(pce, web_service):
+    http_service = pce.services.get(params={'name': 'S-HTTP', 'max_results': 1})[0]
+    assert len(web_service.service_ports) == len(http_service.service_ports)
+    assert set([(sp.port, sp.proto) for sp in web_service.service_ports]) == set([(sp.port, sp.proto) for sp in http_service.service_ports])
+
+
+def test_proto_encoding():
+    https_service_port = ServicePort(port=443, proto='tcp')
+    assert https_service_port.proto == convert_protocol('tcp')
+    encoded_https_service_port = json.loads(json.dumps(https_service_port, cls=IllumioEncoder))
+    assert encoded_https_service_port == {'port': 443, 'proto': 6}
+
+
+def test_get_default_service(pce):
+    default_service = pce.services.get(params={'name': DEFAULT_SERVICE_NAME, 'max_results': 1}, policy_version=ACTIVE)[0]
+    assert default_service.name == DEFAULT_SERVICE_NAME
+
+
+def test_get_by_reference(pce):
+    any_service = pce.services.get_by_reference('/orgs/1/sec_policy/active/services/1')
+    assert any_service.name == DEFAULT_SERVICE_NAME
+
+
+def test_get_by_name(pce):
+    services = pce.services.get(params={'name': 'S-'}, policy_version=DRAFT)
+    assert len(services) == 2
+
+
+def test_get_active_service(pce):
+    services = pce.services.get(params={'name': 'S-'}, policy_version=ACTIVE)
+    assert len(services) == 0
+
+
+def test_create_service(pce, web_service):
+    service = pce.services.create(web_service)
+    assert service.href != ''
+    fetched_service = pce.services.get_by_reference(service.href)
+    assert fetched_service == service
+
+
+def test_update_service(pce):
+    service = pce.services.get(params={'name': 'S-HTTP', 'max_results': 1})[0]
+    pce.services.update(service.href, {'service_ports': [ServicePort(port=8080, proto='tcp')]})
+    updated_service = pce.services.get_by_reference(service.href)
+    print(updated_service)
+    assert len(updated_service.service_ports) > 0
+    assert updated_service.service_ports[0].port == 8080


### PR DESCRIPTION
Improvements to unit and integration tests.

* add unit tests for services
* add rule set unit tests for comparing scopes values
* fix LabelSet comparison to ignore list ordering
* update integration tests to compare HREFs rather than entire objects as dataclass equality may fail on list comparisons - we can't guarantee list order from the PCE

- [x] I've read and followed the [contribution guidelines](CONTRIBUTING.md) for this PR  
