### PR TITLE
Fix #19 - check_connection failing for SaaS PCEs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,8 +1,15 @@
 Changelog
 =========
 
-Version 1.1.0 (2022-08-18)
+Version 1.1.1 (TBD)
 -------------------
+
+.. rubric:: BUG FIXES
+
+* fix check_connection call to work with SaaS PCEs
+
+Version 1.1.0 (2022-08-18)
+--------------------------
 
 .. rubric:: NEW FEATURES
 

--- a/illumio/pce.py
+++ b/illumio/pce.py
@@ -336,7 +336,7 @@ class PolicyComputeEngine:
         """
         try:
             self.get('/health', **{**kwargs, **{'include_org': False}})
-            self.get('/settings/events', **{**kwargs, **{'include_org': True}})
+            self.get('/sec_policy/1', **{**kwargs, **{'include_org': True}})
             return True
         except IllumioApiException:
             return False


### PR DESCRIPTION
A second call was added to `check_connection` to validate the `org_id` parameter, but SaaS PCEs don't support the `/settings` endpoints. Change to `/sec_policy/1` instead (the default base policy version, applies across orgs) for the same effect across both SaaS and on-prem PCEs.

Still not ideal, but seems like the best Public Stable org endpoint that will work for both.

* change second check_connection call to work with SaaS PCEs

- [x] I've read and followed the [contribution guidelines](CONTRIBUTING.md) for this PR  
