### PR TITLE
FIX: check_connection 404s on some PCEs

### DIFF
--- a/illumio/pce.py
+++ b/illumio/pce.py
@@ -356,7 +356,9 @@ class PolicyComputeEngine:
         """
         try:
             self.get('/health', **{**kwargs, **{'include_org': False}})
-            self.get('/sec_policy/1', **{**kwargs, **{'include_org': True}})
+            # make an /orgs/{org_id} call to validate the org ID as well
+            # /settings/workloads is a relatively quick call that will work on SaaS PCEs
+            self.get('/settings/workloads', **{**kwargs, **{'include_org': True}})
             return True
         except IllumioApiException:
             return False


### PR DESCRIPTION
In certain cases, the `sec_policy/1` object may have been removed from the PCE, so use `/settings/workloads` instead.

`/settings/workloads` works on both SaaS and on-prem PCEs, is Public Stable as of 21.5, and is as close to a no-op health check as I think we can get for `/orgs/` endpoints.

- [x] I've read and followed the [contribution guidelines](CONTRIBUTING.md) for this PR  
