### PR TITLE
Fix PCE response NoneType exception

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+Version 1.1.3 (TBD)
+-------------------
+
+.. rubric:: BUG FIXES
+
+* fix issue where PCE request could throw NoneType exception if incorrectly configured
+
 Version 1.1.2 (2022-10-17)
 --------------------------
 

--- a/illumio/pce.py
+++ b/illumio/pce.py
@@ -187,10 +187,10 @@ class PolicyComputeEngine:
             return response
         except Exception as e:
             message = str(e)
-            content_type = response.headers.get('Content-Type', '')
             # Response objects are falsy if the request failed so do a null check
-            if response is not None and content_type == 'application/json':
-                message = self._get_error_message_from_response(response)
+            if response is not None:
+                if response.headers.get('Content-Type', '') == 'application/json':
+                    message = self._get_error_message_from_response(response)
             raise IllumioApiException(message) from e
 
     def _build_url(self, endpoint: str, include_org: bool):

--- a/illumio/pce.pyi
+++ b/illumio/pce.pyi
@@ -19,7 +19,8 @@ class PolicyComputeEngine:
     base_url: str
     org_id: str
 
-    def __init__(self, url: str, port: str, version: str, org_id: str) -> None: ...
+    def __init__(self, url: str, port: str, version: str, org_id: str,
+                    retry_count: int = 5, request_timeout: int = 30) -> None: ...
 
     def _validate(self) -> None: ...
 

--- a/tests/integration/test_intg_pce.py
+++ b/tests/integration/test_intg_pce.py
@@ -1,8 +1,16 @@
-from illumio import PolicyComputeEngine
+import pytest
+
+from illumio import PolicyComputeEngine, IllumioApiException
 
 
 def test_pce_connection(pce: PolicyComputeEngine):
     assert pce.check_connection()
+
+
+def test_invalid_url():
+    pce = PolicyComputeEngine('https://invalid.url.comxyz', retry_count=0)
+    with pytest.raises(IllumioApiException):
+        pce.get('/invalid_endpoint')
 
 
 def test_invalid_org_id(pce: PolicyComputeEngine):


### PR DESCRIPTION
* fix issue where if a requests call encountered an error and returned a null Response object, a NoneType exception was raised from the catch block
* update pce.pyi init signature
* add integration test to cover the failure case

- [x] I've read and followed the [contribution guidelines](CONTRIBUTING.md) for this PR  
