### PR TITLE
Fix #26 - Add must_connect function

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ Version 1.1.3 (TBD)
 .. rubric:: NEW FEATURES
 
 * add `PolicyComputeEngine.set_tls_settings` function to update verify and cert values for PCE requests session
+* add `PolicyComputeEngine.must_connect` function to complement `check_connection`, raising the exception on failure rather than suppressing it
 
 .. rubric:: BUG FIXES
 

--- a/illumio/pce.py
+++ b/illumio/pce.py
@@ -362,8 +362,18 @@ class PolicyComputeEngine:
                 break
         return collection_href
 
+    def must_connect(self, **kwargs) -> None:
+        """Checks the connection to the PCE.
+
+        Additional keyword arguments are passed to the requests call.
+
+        Raises:
+            IllumioApiException: if the connection fails.
+        """
+        self._check_pce_connection(**kwargs)
+
     def check_connection(self, **kwargs) -> bool:
-        """Makes a GET request to the PCE /health endpoint.
+        """Checks the connection to the PCE.
 
         Additional keyword arguments are passed to the requests call.
 
@@ -371,13 +381,16 @@ class PolicyComputeEngine:
             bool: True if the call is successful, otherwise False.
         """
         try:
-            self.get('/health', **{**kwargs, **{'include_org': False}})
-            # make an /orgs/{org_id} call to validate the org ID as well
-            # /settings/workloads is a relatively quick call that will work on SaaS PCEs
-            self.get('/settings/workloads', **{**kwargs, **{'include_org': True}})
+            self._check_pce_connection(**kwargs)
             return True
         except IllumioApiException:
             return False
+
+    def _check_pce_connection(self, **kwargs):
+        self.get('/health', **{**kwargs, **{'include_org': False}})
+        # make an /orgs/{org_id} call to validate the org ID as well
+        # /settings/workloads is a relatively quick call that will work on SaaS PCEs
+        self.get('/settings/workloads', **{**kwargs, **{'include_org': True}})
 
     class _PCEObjectAPI:
         """Generic API for registered PCE objects.

--- a/illumio/pce.pyi
+++ b/illumio/pce.pyi
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 """Stub for PCE interface function definitions"""
-from typing import Any, List, overload
+from typing import Any, List, Union, overload
 
 from requests import Response
 
@@ -32,6 +32,8 @@ class PolicyComputeEngine:
 
     def set_timeout(self, timeout: int) -> None: ...
 
+    def set_tls_settings(self, verify: Union[bool, str] = True, cert: Union[str, tuple] = None) -> None: ...
+
     def _request(self, method: str, endpoint: str, include_org: bool, **kwargs) -> Response: ...
 
     def _build_url(self, endpoint: str, include_org: bool): ...
@@ -56,6 +58,8 @@ class PolicyComputeEngine:
     def _async_poll(self, job_location: str, retry_time: float) -> str: ...
 
     def check_connection(self, **kwargs) -> bool: ...
+
+    def must_connect(self, **kwargs) -> None: ...
 
     class _PCEObjectAPI:
         def __init__(self, pce: 'PolicyComputeEngine', api_data: object) -> None: ...

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,28 +1,14 @@
-import os
-
 import pytest
 
-from illumio import PolicyComputeEngine, IllumioException
-
-from helpers import random_string
+from helpers import random_string, pce_from_env
 from sweepers import Sweeper
-
-# environment variables for integration tests
-pce_host = os.getenv('ILLUMIO_PCE_HOST')
-pce_port = os.getenv('ILLUMIO_PCE_PORT', 443)
-org_id = os.getenv('ILLUMIO_PCE_ORG_ID', 1)
-api_key = os.getenv('ILLUMIO_API_KEY_USERNAME')
-api_secret = os.getenv('ILLUMIO_API_KEY_SECRET')
 
 
 @pytest.fixture(scope='session')
 def pce():
-    if not pce_host or not api_key or not api_secret:
-        raise IllumioException('''Missing required environment variable for integration tests.
-Make sure ILLUMIO_PCE_HOST, ILLUMIO_API_KEY_USERNAME, and ILLUMIO_API_KEY_SECRET are set.''')
-    pce = PolicyComputeEngine(pce_host, port=pce_port, org_id=org_id)
-    pce.set_credentials(api_key, api_secret)
-    return pce
+    _pce = pce_from_env()
+    _pce.must_connect()
+    yield _pce
 
 
 @pytest.fixture(scope='session')

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -1,5 +1,23 @@
+import os
 import random
 from string import ascii_letters, digits
+
+from illumio import PolicyComputeEngine, IllumioException
+
+pce_host = os.getenv('ILLUMIO_PCE_HOST')
+pce_port = os.getenv('ILLUMIO_PCE_PORT', 443)
+org_id = os.getenv('ILLUMIO_PCE_ORG_ID', 1)
+api_key = os.getenv('ILLUMIO_API_KEY_USERNAME')
+api_secret = os.getenv('ILLUMIO_API_KEY_SECRET')
+
+
+def pce_from_env(**kwargs):
+    if not pce_host or not api_key or not api_secret:
+        raise IllumioException('''Missing required environment variable for integration tests.
+Make sure ILLUMIO_PCE_HOST, ILLUMIO_API_KEY_USERNAME, and ILLUMIO_API_KEY_SECRET are set.''')
+    pce = PolicyComputeEngine(pce_host, port=pce_port, org_id=org_id, **kwargs)
+    pce.set_credentials(api_key, api_secret)
+    return pce
 
 
 def random_string():


### PR DESCRIPTION
Adds `PolicyComputeEngine::must_connect` to complement `check_connection`, raising the exception on failure rather than suppressing it

- [x] I've read and followed the [contribution guidelines](CONTRIBUTING.md) for this PR  
