### PR TITLE
36 - Fix LabelGroup subgroup parsing

### DIFF
--- a/illumio/util/functions.py
+++ b/illumio/util/functions.py
@@ -15,7 +15,6 @@ import sys
 import typing
 import warnings
 from dataclasses import dataclass
-from typing import Any
 from urllib.parse import urlparse
 
 from illumio._version import version
@@ -179,7 +178,7 @@ def convert_protocol(protocol: str) -> int:
         raise IllumioException('Invalid protocol name: {}'.format(protocol))
 
 
-def validate_int(val: Any, minimum: int=0, maximum: int=sys.maxsize) -> None:
+def validate_int(val: typing.Any, minimum: int=0, maximum: int=sys.maxsize) -> None:
     """Validates a given value is an integer and is within min <= val <= max.
 
     Args:

--- a/illumio/util/jsonutils.py
+++ b/illumio/util/jsonutils.py
@@ -47,42 +47,7 @@ class JsonObject(ABC):
         self._validate()
 
     def _validate(self):
-        """Validates all dataclass fields against their indicated types."""
-        for field in fields(self):
-            value = getattr(self, field.name)
-            if not self._validate_field(field.type, value):
-                raise AttributeError("Invalid value for {}: {}. Must be of type {}".format(field.name, value, field.type))
-
-    def _validate_field(self, expected_type, value) -> bool:
-        if value is None:
-            return True
-        elif expected_type is object:
-            return True
-        elif type(value) == expected_type:
-            return True
-        elif isunion(expected_type):
-            return any(self._validate_field(type_, value) for type_ in expected_type.__args__)
-        elif isinstance(type(value), IllumioEnumMeta):
-            # validate enum values if they are passed as enum consts
-            return self._validate_field(expected_type, value.value)
-        elif isclass(expected_type) and issubclass(expected_type, JsonObject):
-            # if the object is already decoded, determine whether it's
-            # a subtype of what the field expects
-            if isinstance(value, JsonObject):
-                return isinstance(value, expected_type)
-            try:
-                # XXX: otherwise, expand objects to run their own validation.
-                #   this is *slow*, but needed to validate deeply nested types
-                expected_type.from_json(value)
-            except:
-                return False
-            return True
-        elif islist(expected_type) and isinstance(value, list):
-            if not value:
-                return True  # empty lists are always valid
-            expected_type = expected_type.__args__[0]
-            return all(self._validate_field(expected_type, o) for o in value)
-        return False
+        """Provides optional validation for dataclass fields."""
 
     def to_json(self) -> Any:
         """Converts the object to a JSON-compatible copy of itself.

--- a/tests/data/label_groups.json
+++ b/tests/data/label_groups.json
@@ -1,0 +1,51 @@
+[
+    {
+        "href": "/orgs/1/sec_policy/draft/label_groups/22016906-613a-4f87-9f6c-70e753868be0",
+        "created_at": "2023-07-20T16:12:35.882Z",
+        "updated_at": "2023-07-20T16:13:16.862Z",
+        "deleted_at": null,
+        "created_by": {
+            "href": "/users/3"
+        },
+        "updated_by": {
+            "href": "/users/3"
+        },
+        "deleted_by": null,
+        "update_type": null,
+        "name": "LG-L-Datacenters",
+        "description": "",
+        "key": "loc",
+        "labels": [],
+        "sub_groups": [
+            {
+                "href": "/orgs/1/sec_policy/draft/label_groups/21380320-6635-4f4c-8276-e98038f156cd",
+                "name": "LG-L-US-Datacenters"
+            }
+        ]
+    },
+    {
+        "href": "/orgs/1/sec_policy/draft/label_groups/21380320-6635-4f4c-8276-e98038f156cd",
+        "created_at": "2023-07-20T16:12:51.465Z",
+        "updated_at": "2023-07-20T16:13:05.772Z",
+        "deleted_at": null,
+        "created_by": {
+            "href": "/users/3"
+        },
+        "updated_by": {
+            "href": "/users/3"
+        },
+        "deleted_by": null,
+        "update_type": null,
+        "name": "LG-L-US-Datacenters",
+        "description": "",
+        "key": "loc",
+        "labels": [
+            {
+                "href": "/orgs/1/labels/13",
+                "key": "loc",
+                "value": "Rackspace"
+            }
+        ],
+        "sub_groups": []
+    }
+]

--- a/tests/unit/test_unit_label_groups.py
+++ b/tests/unit/test_unit_label_groups.py
@@ -5,8 +5,6 @@ from typing import List
 
 import pytest
 
-from illumio.policyobjects import IPList, IPRange
-
 LABEL_GROUPS = os.path.join(pytest.DATA_DIR, 'label_groups.json')
 
 
@@ -14,18 +12,6 @@ LABEL_GROUPS = os.path.join(pytest.DATA_DIR, 'label_groups.json')
 def label_groups() -> List[dict]:
     with open(LABEL_GROUPS, 'r') as f:
         yield json.loads(f.read())
-
-
-@pytest.fixture(scope='module')
-def new_label_group() -> IPList:
-    return IPList(
-        name="IPL-INTERNAL",
-        ip_ranges=[
-            IPRange(from_ip='10.0.0.0/8'),
-            IPRange(from_ip='172.16.0.0/12'),
-            IPRange(from_ip='192.168.0.0', to_ip='192.168.255.255')
-        ]
-    )
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/test_unit_label_groups.py
+++ b/tests/unit/test_unit_label_groups.py
@@ -1,0 +1,47 @@
+import json
+import os
+import re
+from typing import List
+
+import pytest
+
+from illumio.policyobjects import IPList, IPRange
+
+LABEL_GROUPS = os.path.join(pytest.DATA_DIR, 'label_groups.json')
+
+
+@pytest.fixture(scope='module')
+def label_groups() -> List[dict]:
+    with open(LABEL_GROUPS, 'r') as f:
+        yield json.loads(f.read())
+
+
+@pytest.fixture(scope='module')
+def new_label_group() -> IPList:
+    return IPList(
+        name="IPL-INTERNAL",
+        ip_ranges=[
+            IPRange(from_ip='10.0.0.0/8'),
+            IPRange(from_ip='172.16.0.0/12'),
+            IPRange(from_ip='192.168.0.0', to_ip='192.168.255.255')
+        ]
+    )
+
+
+@pytest.fixture(autouse=True)
+def label_groups_mock(pce_object_mock, label_groups):
+    pce_object_mock.add_mock_objects(label_groups)
+
+
+@pytest.fixture(autouse=True)
+def mock_requests(requests_mock, get_callback, post_callback, put_callback, delete_callback):
+    pattern = re.compile('/sec_policy/(draft|active)/label_groups')
+    requests_mock.register_uri('GET', pattern, json=get_callback)
+    requests_mock.register_uri('POST', pattern, json=post_callback)
+    requests_mock.register_uri('PUT', pattern, json=put_callback)
+    requests_mock.register_uri('DELETE', pattern, json=delete_callback)
+
+
+def test_nested_label_groups(pce):
+    label_group = pce.label_groups.get_by_name(name="LG-L-Datacenters")
+    assert len(label_group.sub_groups) > 0


### PR DESCRIPTION
Label group objects with subgroups were failing to parse due to issues with the internal field validation in `JsonObject`. `ForwardRef` fields were not being resolved, so the strict field type checks were failing.

Rather than continuing to write more and more complex rules for field validation, this change removes top-level strict field validation entirely; it was inflexible and slow for little return. Instead, future changes should focus on reflecting API validation errors back to the user and improving inconsistent or unclear error messages.

- [x] I've read and followed the [contribution guidelines](CONTRIBUTING.md) for this PR  
