### PR TITLE
Increase Processing Speed of Traffic Flow Objects using multi-processing

### DIFF
--- a/illumio/pce.py
+++ b/illumio/pce.py
@@ -24,9 +24,7 @@ Copyright:
 License:
     Apache2, see LICENSE for more details.
 """
-import concurrent.futures
 import json
-import multiprocessing
 import time
 from typing import Any, List, Union
 from requests import Session, Response

--- a/illumio/pce.py
+++ b/illumio/pce.py
@@ -946,6 +946,7 @@ class PolicyComputeEngine:
             collection_href = self._async_poll(location)
             response = self.get(collection_href)
             response.raise_for_status()
+            raw_flow_data = response.json()
             if len(response.json()) > 10000:
                 return TrafficFlow.from_json_mp(raw_flow_data)
             else:

--- a/illumio/pce.py
+++ b/illumio/pce.py
@@ -947,7 +947,7 @@ class PolicyComputeEngine:
             response = self.get(collection_href)
             response.raise_for_status()
             raw_flow_data = response.json()
-            if len(response.json()) > 10000:
+            if len(raw_flow_data) > 10000:
                 return TrafficFlow.from_json_mp(raw_flow_data)
             else:
                 return [TrafficFlow.from_json(flow) for flow in raw_flow_data]

--- a/illumio/pce.py
+++ b/illumio/pce.py
@@ -29,8 +29,6 @@ import json
 import multiprocessing
 import time
 from typing import Any, List, Union
-
-from tqdm import tqdm
 from requests import Session, Response
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
@@ -943,29 +941,26 @@ class PolicyComputeEngine:
             kwargs['include_org'] = True
             response = self.post('/traffic_flows/async_queries', **kwargs)
             response.raise_for_status()
-            print(f"Transforming Json data into TrafficFlow Objects...")
+            query_status = response.json()
+            location = query_status['href']
+            collection_href = self._async_poll(location)
+            response = self.get(collection_href)
+            response.raise_for_status()
             raw_flow_data = response.json()
             rfd_len = len(raw_flow_data)
             if rfd_len == 0:
                 return []
-            if rfd_len > 10000:
-                print(f"Traffic Search Returned: {rfd_len} flows, using multiprocessing...")
-                cpu_count = multiprocessing.cpu_count()
-                chunksize = int(len(raw_flow_data) / (10 * cpu_count))
-                with concurrent.futures.ProcessPoolExecutor(max_workers=cpu_count/2) as executor:
-                    results = list(
-                        tqdm(executor.map(self._transform_traffic_flows, raw_flow_data, chunksize=chunksize), total=len(raw_flow_data), desc="Loading Traffic Search Results",
-                             unit="flows"))
             else:
-                print(f"Traffic Search Returned: {len(raw_flow_data)} flows, using single process...")
-                results = [TrafficFlow.from_json(flow) for flow in raw_flow_data]
+                if rfd_len > 10000:
+                    cpu_count = multiprocessing.cpu_count()
+                    chunksize = int(rfd_len / (10 * cpu_count))
+                    with concurrent.futures.ProcessPoolExecutor(max_workers=cpu_count/2) as executor:
+                        return list(executor.map(TrafficFlow.from_json, raw_flow_data, chunksize=chunksize))
+                else:
+                    results = [TrafficFlow.from_json(flow) for flow in raw_flow_data]
             return results
         except Exception as e:
             raise IllumioApiException from e
-
-    @staticmethod
-    def _transform_traffic_flows(flow):
-        return TrafficFlow.from_json(flow)
 
     def provision_policy_changes(self, change_description: str, hrefs: List[str], **kwargs) -> PolicyVersion:
         """Provisions policy changes for draft objects with the given HREFs.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,9 @@
 -e .
 dataclasses>=0.8; python_version == '3.6'
-pytest
+pytest~=7.2.2
 pytest-cov
 requests>=2.26.0
 requests-mock
+
+tqdm~=4.66.1
+urllib3~=1.26.15

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,8 @@
 -e .
 dataclasses>=0.8; python_version == '3.6'
-pytest~=7.2.2
+pytest
 pytest-cov
 requests>=2.26.0
 requests-mock
 
 tqdm~=4.66.1
-urllib3~=1.26.15

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,3 @@ pytest
 pytest-cov
 requests>=2.26.0
 requests-mock
-
-tqdm~=4.66.1


### PR DESCRIPTION
Could be considered an alternative to removing validate
* decides whether to use single process or multipe processes depending on number of flows
* displays tqdm progress bar when using multiprocessing
* uses chunk sizes to minimize number of rpc calls to transfer data

pce.py
- Added imports for concurrent.futures, multiprocessing, and tqdm.
- Refactored the method `_get_traffic_flows()` to use multiprocessing for improved performance when the number of flows is greater than 10,000.
- Added a static method `_transform_traffic_flows()` to handle the transformation of raw flow data into TrafficFlow objects.

requirements.txt:
- Updated the version of pytest to `7.2.2`.
- Added tqdm (`4.66.1`) and urllib3 (`1.26.15`) to the requirements.


cProfile results for single process (original list comprehension) method:
```
Traffic Search Returned: 74 flows, using single process...
         329733963 function calls (310837371 primitive calls) in 132.544 seconds

   Ordered by: cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        4    0.025    0.006  133.438   33.360 pce.py:945(<listcomp>)
1129211/18353    5.047    0.000  133.413    0.007 jsonutils.py:111(from_json)
1129211/264934    0.446    0.000  101.614    0.000 jsonutils.py:46(__post_init__)
1129211/264934    6.207    0.000  101.378    0.000 jsonutils.py:141(_decode_complex_types)
1129211/264934    4.958    0.000  101.278    0.000 jsonutils.py:49(_validate)
9865408/2796931    3.067    0.000   98.476    0.000 jsonutils.py:56(_validate_field)
9791996/2796931    3.188    0.000   98.080    0.000 jsonutils.py:147(_decode_field)
  1129211    0.572    0.000   89.312    0.000 inspect.py:3276(signature)
  1129211    0.843    0.000   88.740    0.000 inspect.py:3022(from_callable)
2258422/1129211   11.030    0.000   87.896    0.000 inspect.py:2425(_signature_from_callable)
    18353    0.044    0.000   65.822    0.004 trafficanalysis.py:286(_validate)
  1129211   15.194    0.000   50.671    0.000 inspect.py:2330(_signature_from_function)
   111918    0.131    0.000   40.198    0.000 {built-in method builtins.all}
   537074    0.266    0.000   40.067    0.000 jsonutils.py:87(<genexpr>)
   537074    0.241    0.000   38.407    0.000 jsonutils.py:158(<genexpr>)
    77016    0.117    0.000   23.803    0.000 workload.py:167(_validate)
    77016    0.102    0.000   23.565    0.000 workload.py:174(_decode_complex_types)
 10496051   13.643    0.000   22.317    0.000 inspect.py:2682(__init__)
  2258422   12.898    0.000   19.456    0.000 inspect.py:2968(__init__)
  1129211    2.620    0.000   15.347    0.000 inspect.py:2045(_signature_bound_method)
  1129211    0.898    0.000   12.172    0.000 inspect.py:3038(replace)
  2258422    4.184    0.000    7.649    0.000 dataclasses.py:1223(fields)
 43644123    4.532    0.000    5.844    0.000 {built-in method builtins.isinstance}
 10496051    4.056    0.000    5.777    0.000 enum.py:689(__call__)
 11625262    3.262    0.000    4.263    0.000 inspect.py:3017(<genexpr>)
  2258422    2.111    0.000    3.783    0.000 inspect.py:735(unwrap)
 20992102    2.968    0.000    2.968    0.000 dataclasses.py:1238(<genexpr>)
 27767368    2.585    0.000    2.585    0.000 {built-in method builtins.getattr}
  1129211    1.667    0.000    2.271    0.000 inspect.py:167(get_annotations)
  1129211    1.043    0.000    2.254    0.000 inspect.py:2071(_signature_is_builtin)
  3387633    1.361    0.000    2.149    0.000 inspect.py:1953(_signature_get_user_defined_method)
  2938422    0.962    0.000    2.119    0.000 {built-in method builtins.issubclass}
```
