### PR TITLE
Fix traffic queries with include filters

### DIFF
--- a/illumio/explorer/trafficanalysis.py
+++ b/illumio/explorer/trafficanalysis.py
@@ -92,8 +92,11 @@ def _parse_traffic_filters(refs: List[Any], include=False) -> List[object]:
                 o = {'ip_address': ref}
             except socket.error:
                 raise IllumioException('Invalid traffic filter type: {}'.format(ref))
-        traffic_objects.append([o] if include else o)
-    return traffic_objects
+        traffic_objects.append(o)
+    if include:
+        return [traffic_objects]
+    else:
+        return traffic_objects
 
 
 @dataclass
@@ -143,8 +146,8 @@ class TrafficQuery(JsonObject):
     @staticmethod
     def build(start_date: Optional[Union[str, int, float]],
             end_date: Optional[Union[str, int, float]],
-            include_sources=[[]], exclude_sources=[],
-            include_destinations=[[]], exclude_destinations=[],
+            include_sources=[], exclude_sources=[],
+            include_destinations=[], exclude_destinations=[],
             include_services=[], exclude_services=[], policy_decisions=[],
             exclude_workloads_from_ip_list_query=True, max_results=100000,
             query_name: str = None) -> 'TrafficQuery':

--- a/illumio/util/jsonutils.py
+++ b/illumio/util/jsonutils.py
@@ -107,7 +107,7 @@ class JsonObject(ABC):
         Multi-process wrapper for from_json to process multiple JSON objects.
         """
         max_workers = max_workers or (cpu_count() // 2)
-        chunksize = int(len(data_list) / (10 * cpu_count))
+        chunksize = int(len(data_list) / (10 * cpu_count()))
 
         with Pool(max_workers) as pool:
             results = pool.map(cls.from_json, data_list, chunksize=chunksize)


### PR DESCRIPTION
This PR fixes querying traffic flows with multiple include filters.

- jsonutils.py: Fix chunksize calculation in from_json_mp() (#43)
- pce.py: Fix Handling of include filters and thus generated http request to handle multiple include filters (#44)

I could not add tests for the fixes, since i only have access to a production PCE. If you provide me with a test-license, I'm happy to add tests though :)

- [ x] I've read and followed the [contribution guidelines](CONTRIBUTING.md) for this PR  
