### PR TITLE
Fix get_all KeyError when X-Total-Count header is missing

### DIFF
--- a/illumio/pce.py
+++ b/illumio/pce.py
@@ -537,7 +537,9 @@ class PolicyComputeEngine:
                 response = self.pce.get(endpoint, **kwargs)
                 if len(response.json()) > 0:  # for endpoints that don't support max_results
                     return [self.object_cls.from_json(o) for o in response.json()]
-                filtered_object_count = response.headers['X-Total-Count']
+                filtered_object_count = response.headers.get('X-Total-Count')
+                if not filtered_object_count:
+                    return []
                 kwargs['params'] = {**params, **{'max_results': int(filtered_object_count)}}
 
             response = self.pce.get(endpoint, **kwargs)

--- a/tests/integration/test_intg_rules.py
+++ b/tests/integration/test_intg_rules.py
@@ -35,6 +35,11 @@ def test_get_by_href(pce, rule):
     assert r.href == rule.href
 
 
+def test_get_all_empty_ruleset(pce, rule_set):
+    rules = pce.rules.get_all(parent=rule_set.href)
+    assert rules == []
+
+
 def test_get_from_rule_set(pce, rule_set, rule):
     rules = pce.rules.get(parent=rule_set.href)
     assert len(rules) == 1

--- a/tests/unit/test_unit_rules.py
+++ b/tests/unit/test_unit_rules.py
@@ -73,3 +73,14 @@ def test_builder():
 def test_get_rules(pce):
     rules = pce.rules.get(parent=MOCK_RULE_SET_HREF)
     assert len(rules) > 0
+
+
+def test_get_all_empty_ruleset(pce, requests_mock):
+    def empty_callback(request, context):
+        return []
+
+    pattern = re.compile('/sec_rules')
+    requests_mock.register_uri('GET', pattern, json=empty_callback)
+
+    rules = pce.rules.get_all(parent=MOCK_RULE_SET_HREF)
+    assert rules == []


### PR DESCRIPTION
Description:
  ## Summary
  - Fixed `get_all` method crash (`KeyError: 'x-total-count'`) when called on an empty ruleset
  - The `/sec_rules` endpoint does not support `max_results` and never returns the `X-Total-Count` header. When a ruleset is empty, the code falls through to read the missing header, causing the crash.
  - Changed `response.headers['X-Total-Count']` to `response.headers.get('X-Total-Count')` and return an empty list when the header is absent.

  ## Test plan
  - [x] Unit test added (`test_get_all_empty_ruleset`) — simulates empty response with no `X-Total-Count` header
  - [x] Integration test added (`test_get_all_empty_ruleset`) — verified against live PCE (`devtest235.core.ilabs.io`)
  - [x] Reproduced bug on `main` branch — confirmed crash
  - [x] Verified fix on feature branch — confirmed `[]` returned successfully
  - [x] Full unit test suite passed (147 tests)
